### PR TITLE
Renamed transmission to transmissions retaining backwards compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Alternatively, you can pass the API key to the SparkPost class:
 
     from sparkpost import SparkPost
     sp = SparkPost('YOUR API KEY')
-    
+
 .. _API & SMTP: https://app.sparkpost.com/#/configuration/credentials
 
 
@@ -56,16 +56,16 @@ Here at SparkPost, our messages are known as transmissions. Let's use the underl
 .. code-block:: python
 
     from sparkpost import SparkPost
-    
+
     sp = SparkPost()
-    
-    response = sp.transmission.send(
+
+    response = sp.transmissions.send(
         recipients=['someone@somedomain.com'],
         html='<p>Hello world</p>',
         from_email='test@sparkpostbox.com',
         subject='Hello from python-sparkpost'
     )
-    
+
     print response
     # outputs {u'total_accepted_recipients': 1, u'id': u'47960765679942446', u'total_rejected_recipients': 0}
 
@@ -75,8 +75,8 @@ Here at SparkPost, our messages are known as transmissions. Let's use the underl
 Documentation
 -------------
 
-* Documentation for `python-sparkpost`_ 
-* `SparkPost API Reference`_ 
+* Documentation for `python-sparkpost`_
+* `SparkPost API Reference`_
 
 .. _python-sparkpost: http://readthedocs.org/docs/python-sparkpost
 .. _SparkPost API Reference: https://www.sparkpost.com/docs/introduction

--- a/sparkpost/__init__.py
+++ b/sparkpost/__init__.py
@@ -2,7 +2,7 @@ import os
 
 from .exceptions import SparkPostException
 from .metrics import Metrics
-from .transmission import Transmission
+from .transmissions import Transmissions
 
 
 __version__ = '1.0.0.dev1'
@@ -26,4 +26,5 @@ class SparkPost(object):
         self.api_key = api_key
 
         self.metrics = Metrics(self.base_uri, self.api_key)
-        self.transmission = Transmission(self.base_uri, self.api_key)
+        self.transmissions = Transmissions(self.base_uri, self.api_key)
+        self.transmission = self.transmissions

--- a/sparkpost/__init__.py
+++ b/sparkpost/__init__.py
@@ -27,4 +27,6 @@ class SparkPost(object):
 
         self.metrics = Metrics(self.base_uri, self.api_key)
         self.transmissions = Transmissions(self.base_uri, self.api_key)
+        # Keeping self.transmission for backwards compatibility.
+        # Will be removed in a future release.
         self.transmission = self.transmissions

--- a/sparkpost/transmissions.py
+++ b/sparkpost/transmissions.py
@@ -3,7 +3,7 @@ import json
 from .base import Resource
 
 
-class Transmission(Resource):
+class Transmissions(Resource):
     """
     Transmission class used to send, list and get transmissions. For detailed
     request and response formats, see the `Transmissions API documentation

--- a/test/test_transmissions.py
+++ b/test/test_transmissions.py
@@ -2,12 +2,12 @@ import pytest
 import responses
 
 from sparkpost import SparkPost
-from sparkpost import Transmission
+from sparkpost import Transmissions
 from sparkpost.exceptions import SparkPostAPIException
 
 
 def test_translate_keys_with_list():
-    t = Transmission('uri', 'key')
+    t = Transmissions('uri', 'key')
     results = t._translate_keys(recipient_list='test')
     assert results['return_path'] == 'default@sparkpostmail.com'
     assert results['options']['open_tracking'] is True
@@ -17,7 +17,7 @@ def test_translate_keys_with_list():
 
 
 def test_translate_keys_with_recips():
-    t = Transmission('uri', 'key')
+    t = Transmissions('uri', 'key')
     results = t._translate_keys(recipients=['test',
                                             {'key': 'value'}, 'foobar'])
     assert results['recipients'] == [{'address': {'email': 'test'}},


### PR DESCRIPTION
Renamed files to transmissions. Kept a reference to `self.transmission` in the `__init__.py`
Closes #34 