### PR TITLE
Add test for __init__ file, resolves #36

### DIFF
--- a/test/test_init.py
+++ b/test/test_init.py
@@ -1,0 +1,9 @@
+import pytest
+
+from sparkpost import SparkPost
+from sparkpost.exceptions import SparkPostException
+
+
+def test_no_api_key():
+    with pytest.raises(SparkPostException):
+        SparkPost()


### PR DESCRIPTION
This adds a test file for the init script and tests the failure condition - where the env var is missing. The other tests in our suite cover the inverse.