### PR TITLE
Use glob to match all files in resources and api folders

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,6 +5,7 @@ API Documentation
 A complete API reference to the :data:`sparkpost` module.
 
 .. toctree::
+   :glob:
    :maxdepth: 1
 
-   api/transmissions
+   api/*

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,11 +42,10 @@ Resources
 The following resources are available in python-sparkpost:
 
 .. toctree::
+    :glob:
     :maxdepth: 1
 
-    resources/metrics
-    resources/templates
-    resources/transmissions
+    resources/*
 
 
 API reference


### PR DESCRIPTION
This uses the ``:glob:`` setting for the toctree so we don't have to manually edit these files. Just add resources and/or api files and they'll get auto-added.