### PR TITLE
Added support for attachments. refs #56

### DIFF
--- a/docs/resources/transmissions.rst
+++ b/docs/resources/transmissions.rst
@@ -54,6 +54,33 @@ Using inline templates and/or recipients
     )
 
 
+Sending an attachment
+*********************
+
+.. code-block:: python
+
+    from sparkpost import SparkPost
+
+    sp = SparkPost()
+
+    sp.transmission.send(
+        recipients=['someone@somedomain.com'],
+        text="Hello world",
+        html='<p>Hello world</p>',
+        from_email='test@sparkpostbox.com',
+        subject='Hello from python-sparkpost',
+        track_opens=True,
+        track_clicks=True,
+        attachments=[
+            {
+                "name": "test.txt",
+                "type": "text/plain",
+                "filename": "/home/sparkpost/a-file.txt"
+            }
+        ]
+    )
+
+
 Using a stored template
 ***********************
 

--- a/test/test_transmissions.py
+++ b/test/test_transmissions.py
@@ -75,6 +75,22 @@ def test_success_send_with_attachments():
         assert test_content == content.decode("ascii")
 
         assert results == 'yay'
+
+        attachment = {
+            "name": "test.txt",
+            "type": "text/plain",
+            "data": base64.b64encode(
+                test_content.encode("ascii")).decode("ascii")
+        }
+        results = sp.transmission.send(attachments=[attachment])
+
+        request_params = json.loads(responses.calls[1].request.body)
+        content = base64.b64decode(
+            request_params["content"]["attachments"][0]["data"])
+        # Let's compare unicode for Python 2 / 3 compatibility
+        assert test_content == content.decode("ascii")
+
+        assert results == 'yay'
     finally:
         os.unlink(temp_file_path)
 

--- a/test/test_transmissions.py
+++ b/test/test_transmissions.py
@@ -1,5 +1,11 @@
+import base64
+import json
+import os
+import tempfile
+
 import pytest
 import responses
+import six
 
 from sparkpost import SparkPost
 from sparkpost import Transmissions
@@ -35,6 +41,42 @@ def test_success_send():
     sp = SparkPost('fake-key')
     results = sp.transmission.send()
     assert results == 'yay'
+
+
+@responses.activate
+def test_success_send_with_attachments():
+    try:
+        # Let's compare unicode for Python 2 / 3 compatibility
+        test_content = six.u("Hello \nWorld\n")
+        (_, temp_file_path) = tempfile.mkstemp()
+        with open(temp_file_path, "w") as temp_file:
+            temp_file.write(test_content)
+
+        responses.add(
+            responses.POST,
+            'https://api.sparkpost.com/api/v1/transmissions',
+            status=200,
+            content_type='application/json',
+            body='{"results": "yay"}'
+        )
+        sp = SparkPost('fake-key')
+
+        attachment = {
+            "name": "test.txt",
+            "type": "text/plain",
+            "filename": temp_file_path
+        }
+        results = sp.transmission.send(attachments=[attachment])
+
+        request_params = json.loads(responses.calls[0].request.body)
+        content = base64.b64decode(
+            request_params["content"]["attachments"][0]["data"])
+        # Let's compare unicode for Python 2 / 3 compatibility
+        assert test_content == content.decode("ascii")
+
+        assert results == 'yay'
+    finally:
+        os.unlink(temp_file_path)
 
 
 @responses.activate


### PR DESCRIPTION
This patch supports both passing a base64-encoded attachment or a filename, which will then be converted to base64. There is some ascii encoding done with the base64 to ensure compatibility between Python 2 and Python 3 (base64 in Python 3 returns a bytestring whereas Python 2 returns a string).

The tests ran successfully with Python 2.7 and Python 3.5.