### PR TITLE
Added tox support. refs #67

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ python:
   - "2.7"
   - "3.4"
 env:
-  - DJANGO_VERSION=1.7
-  - DJANGO_VERSION=1.8
-  - DJANGO_VERSION=1.9b1
+  - DJANGO_VERSION='>=1.7,<1.8'
+  - DJANGO_VERSION='>=1.8,<1.9'
+  - DJANGO_VERSION='>=1.9,<1.10'
 install:
   - pip install -r dev-requirements.txt
   - pip uninstall django --yes
-  - pip install -q django==$DJANGO_VERSION
+  - pip install -q django$DJANGO_VERSION
   - pip install coveralls
   - pip install -e .
 before_script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,23 @@ Once you are set up for local development:
 * Run ``make test`` to test against your current Python environment
 * Open htmlcov/index.html to view coverage information
 
+### Testing all version combinations
+
+You can also test all the supported Python and dependencies versions with tox:
+
+1. Install tox: ``pip install tox``
+2. Run tox: ``tox``
+
+If you do not have Python 2.7, 3.4, and 3.5, you can install them with pyenv:
+
+1. Install [pyenv](https://github.com/yyuu/pyenv)
+2. Install the required versions of Python:
+    1. ``pyenv install 2.7.11``
+    2. ``pyenv install 3.4.4``
+    3. ``pyenv install 3.5.1``
+3. Set the global versions: ``pyenv global 2.7.11 3.4.4 3.5.1``
+4. Run tox: ``tox``
+
 ## Releasing
 
 To put python-sparkpost on PyPI

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,4 @@
-flake8
-pytest==2.6.4
-pytest-cov==1.8.1
-requests==2.5.1
-responses==0.3.0
+-r test-requirements.txt
 wheel
 twine
-Django>=1.8,<1.9
+Django>=1.7,<1.10

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,5 @@
+flake8
+pytest==2.8.7
+pytest-cov==1.8.1
+requests==2.5.1
+responses==0.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = {py27,py34}-django{17,18}, py35-django{18,19}
+
+[testenv]
+deps =
+    -rtest-requirements.txt
+    django17: Django>=1.7,<1.8
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+
+commands = py.test test/
+
+[testenv:py35-django19]
+
+commands =
+    flake8 sparkpost test
+    py.test --cov-report term-missing --cov-report html --cov sparkpost test/


### PR DESCRIPTION
This pull request adds tox support, which I find very useful to test various combination of versions locally.

Some small additional changes:
1. I had to update the version of pytest to make it work with Python 3.5
2. I had to split the requirements file because tox install all dependencies at the same time, so it was complaining about the conflicting Django versions (one in dev-requirements.txt and one in tox.ini): I changed it so that all the other commands, e.g., make install or make test, should not be affected.
3. I updated the travis config to test the latest Django versions, e.g., Django 1.7.11 instead of Django 1.7