### PR TITLE
added email address parsing

### DIFF
--- a/sparkpost/transmissions.py
+++ b/sparkpost/transmissions.py
@@ -1,5 +1,6 @@
 import base64
 import json
+from email.utils import parseaddr
 
 from .base import Resource
 
@@ -84,7 +85,16 @@ class Transmissions(Resource):
             except NameError:
                 string_types = str  # Python 3 doesn't have basestring
             if isinstance(recip, string_types):
-                formatted_recipients.append({'address': {'email': recip}})
+                name, email = parseaddr(recip)
+                formatted_recip = {
+                    'address': {
+                        'name': name,
+                        'email': email
+                    }
+                }
+                if not name:
+                    del formatted_recip['address']['name']
+                formatted_recipients.append(formatted_recip)
             else:
                 formatted_recipients.append(recip)
         return formatted_recipients

--- a/test/test_transmissions.py
+++ b/test/test_transmissions.py
@@ -39,6 +39,16 @@ def test_translate_keys_with_unicode_recips():
     ]
 
 
+def test_translate_keys_for_email_parsing():
+    t = Transmissions('uri', 'key')
+    results = t._translate_keys(recipients=['hansel@example.com',
+                                            'Gretel <gretel@example.com>'])
+    assert results['recipients'] == [
+        {'address': {'email': 'hansel@example.com'}},
+        {'address': {'name': 'Gretel', 'email': 'gretel@example.com'}}
+    ]
+
+
 @responses.activate
 def test_success_send():
     responses.add(


### PR DESCRIPTION
Adds support for emails with names (e.g. `Joe Smith <joesmith@example.com>`) for recipients.