### PR TITLE
Added support for setting from_name

### DIFF
--- a/sparkpost/transmissions.py
+++ b/sparkpost/transmissions.py
@@ -41,7 +41,7 @@ class Transmissions(Resource):
         model['content']['subject'] = kwargs.get('subject')
         if kwargs.get('from_name'):
             model['content']['from'] = {
-                'name': kwargs.get('from_name') or '',
+                'name': kwargs.get('from_name'),
                 'email': kwargs.get('from_email')
             }
         else:

--- a/sparkpost/transmissions.py
+++ b/sparkpost/transmissions.py
@@ -41,7 +41,7 @@ class Transmissions(Resource):
         model['content']['subject'] = kwargs.get('subject')
         if kwargs.get('from_name'):
             model['content']['from'] = {
-                'name': kwargs.get('from_name'), 
+                'name': kwargs.get('from_name') or '',
                 'email': kwargs.get('from_email')
             }
         else:

--- a/sparkpost/transmissions.py
+++ b/sparkpost/transmissions.py
@@ -39,7 +39,13 @@ class Transmissions(Resource):
             kwargs.get('use_draft_template', False)
         model['content']['reply_to'] = kwargs.get('reply_to')
         model['content']['subject'] = kwargs.get('subject')
-        model['content']['from'] = kwargs.get('from_email')
+        if kwargs.get('from_name'):
+            model['content']['from'] = {
+                'name': kwargs.get('from_name'), 
+                'email': kwargs.get('from_email')
+            }
+        else:
+            model['content']['from'] = kwargs.get('from_email')
         model['content']['html'] = kwargs.get('html')
         model['content']['text'] = kwargs.get('text')
         model['content']['template_id'] = kwargs.get('template')


### PR DESCRIPTION
Accordingly to official documentation [1], "from" parameter can be just a string (an email address), or a JSON dictionary, with the keys "name" and "email". So I've extended the send method to check for the "from_name" parameter, and if it's present, sending a dictionary instead of just the email.

[1] https://developers.sparkpost.com/api/#/reference/transmissions