### PR TITLE
Support for cc/bcc in Django backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,9 @@ The SparkPost python library comes with an email backend for Django. Put the fol
     SPARKPOST_API_KEY = 'API_KEY'
     EMAIL_BACKEND = 'sparkpost.django.email_backend.SparkPostEmailBackend'
 
-Replace *API_KEY* with an actual API key that you've generated in `Get a Key`_ section.
+Replace *API_KEY* with an actual API key that you've generated in `Get a Key`_ section. Check out the `full documentation`_ on the Django email backend.
+
+.. _full documentation: http://python-sparkpost.readthedocs.org/en/latest/django/backend.html
 
 Documentation
 -------------

--- a/docs/django/backend.rst
+++ b/docs/django/backend.rst
@@ -37,25 +37,39 @@ Django is now configured to use the SparkPost email backend. You can now send ma
     from django.core.mail import send_mail
 
     send_mail(
-        subject='hello from sparkpost',
-        message='Hello Rock stars!'
+        subject='Hello from SparkPost',
+        message='Woo hoo! Sent from Django!'
         from_email='from@yourdomain.com',
-        recipient_list=['to@friendsdomain.com'],
+        recipient_list=['to@example.com'],
         html_message='<p>Hello Rock stars!</p>',
     )
+
+If you need to add cc, bcc, reply to, or attachments, use the `EmailMultiAlternatives` class directly:
+
+.. code-block:: python
+
+    from django.core.mail import EmailMultiAlternatives
+
+    email = EmailMultiAlternatives(
+      subject='hello from sparkpost',
+      message='Woo hoo! Sent from Django!'
+      from_email='from@yourdomain.com',
+      to=['to@example.com'],
+      cc=['ccone@example.com'],
+      bcc=['bccone@example.com'],
+      reply_to=['replyone@example.com']
+    )
+
+    email.attach_alternative('<p>Woo hoo! Sent from Django!</p>', 'text/html')
+    email.attach('image.png', img_data, 'image/png')
+    email.send()
 
 
 Supported version
 -----------------
-SparkPost will support all versions of Django that are within extended support period. Refer to `Django Supported_Version`_.
+SparkPost will support all versions of Django that are within extended support period. Refer to `Django Supported Versions`_.
 
-Current supported versions are:
-    * 1.7
-    * 1.8
-    * 1.9b1
-
-
-.. _Django Supported_Version: https://www.djangoproject.com/download/#supported-versions
+.. _Django Supported Versions: https://www.djangoproject.com/download/#supported-versions
 
 
 Additional documentation
@@ -64,4 +78,3 @@ Additional documentation
 See our `Using SparkPost with Django`_ in support article.
 
 .. _Using SparkPost with Django: https://support.sparkpost.com/customer/en/portal/articles/2169630-using-sparkpost-with-django?b_id=7411
-

--- a/docs/django/backend.rst
+++ b/docs/django/backend.rst
@@ -52,7 +52,7 @@ If you need to add cc, bcc, reply to, or attachments, use the `EmailMultiAlterna
 
     email = EmailMultiAlternatives(
       subject='hello from sparkpost',
-      message='Woo hoo! Sent from Django!'
+      body='Woo hoo! Sent from Django!',
       from_email='from@yourdomain.com',
       to=['to@example.com'],
       cc=['ccone@example.com'],

--- a/sparkpost/django/message.py
+++ b/sparkpost/django/message.py
@@ -33,7 +33,7 @@ class SparkPostMessage(dict):
             formatted['bcc'] = message.bcc
 
         if hasattr(message, 'reply_to') and message.reply_to:
-            formatted['reply_to'] = message.reply_to
+            formatted['reply_to'] = ','.join(message.reply_to)
 
         if isinstance(message, EmailMultiAlternatives):
             for alternative in message.alternatives:

--- a/sparkpost/django/message.py
+++ b/sparkpost/django/message.py
@@ -32,7 +32,7 @@ class SparkPostMessage(dict):
         if message.bcc:
             formatted['bcc'] = message.bcc
 
-        if message.reply_to:
+        if hasattr(message, 'reply_to') and message.reply_to:
             formatted['reply_to'] = message.reply_to
 
         if isinstance(message, EmailMultiAlternatives):

--- a/sparkpost/django/message.py
+++ b/sparkpost/django/message.py
@@ -1,0 +1,53 @@
+from django.core.mail import EmailMultiAlternatives
+
+from .exceptions import UnsupportedContent
+
+
+class SparkPostMessage(dict):
+    """
+    Takes a Django EmailMessage and formats it for use with the SparkPost API.
+
+    The dictionary returned would be formatted like this:
+
+    {
+        'recipients': ['recipient@example.com'],
+        'from_email': 'from@example.com',
+        'text': 'Hello world',
+        'html': '<p>Hello world</p>',
+        'subject': 'Hello from the SparkPost Django email backend'
+    }
+    """
+
+    def __init__(self, message):
+        formatted = {
+            'recipients': message.to,
+            'from_email': message.from_email,
+            'subject': message.subject,
+            'text': message.body
+        }
+
+        if message.cc:
+            formatted['cc'] = message.cc
+
+        if message.bcc:
+            formatted['bcc'] = message.bcc
+
+        if message.reply_to:
+            formatted['reply_to'] = message.reply_to
+
+        if isinstance(message, EmailMultiAlternatives):
+            for alternative in message.alternatives:
+                if alternative[1] == 'text/html':
+                    formatted['html'] = alternative[0]
+                else:
+                    raise UnsupportedContent(
+                        'Content type %s is not supported' % alternative[1]
+                    )
+
+        if message.attachments:
+            raise UnsupportedContent(
+                'The SparkPost Django email backend does not '
+                'currently support attachment.'
+            )
+
+        return super(SparkPostMessage, self).__init__(formatted)

--- a/test/django/test_email_backend.py
+++ b/test/django/test_email_backend.py
@@ -1,8 +1,6 @@
 import pytest
 import mock
-from distutils.version import StrictVersion
 
-from django import get_version
 from django.conf import settings
 from django.core.mail import send_mail
 from django.core.mail import send_mass_mail
@@ -28,10 +26,6 @@ reconfigure_settings(
     EMAIL_BACKEND='sparkpost.django.email_backend.SparkPostEmailBackend',
     SPARKPOST_API_KEY=API_KEY
 )
-
-
-def at_least_version(version):
-    return StrictVersion(get_version()) > StrictVersion(version)
 
 
 def get_params(overrides=None):

--- a/test/django/test_email_backend.py
+++ b/test/django/test_email_backend.py
@@ -6,19 +6,12 @@ from django import get_version
 from django.conf import settings
 from django.core.mail import send_mail
 from django.core.mail import send_mass_mail
-from django.core.mail import EmailMessage
 from django.core.mail import EmailMultiAlternatives
 from django.utils.functional import empty
 
 from sparkpost.django.email_backend import SparkPostEmailBackend
-from sparkpost.django.exceptions import UnsupportedParam
 from sparkpost.django.exceptions import UnsupportedContent
 from sparkpost.transmissions import Transmissions
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 API_KEY = 'API_Key'
 
@@ -172,49 +165,6 @@ def test_unsupported_content_types():
             params['recipient_list'])
         mail.attach_alternative('<ppp>non-plain content</ppp>', 'text/alien')
         mail.send()
-
-
-def test_attachment():
-    params = get_params()
-    params['body'] = params.pop('message')
-    params['to'] = params.pop('recipient_list')
-
-    attachment = StringIO()
-    attachment.write('hello file')
-    email = EmailMessage(**params)
-    email.attach('file.txt', attachment, 'text/plain')
-
-    with pytest.raises(UnsupportedContent):
-        email.send()
-
-
-def test_cc_bcc_reply_to():
-    params = get_params({
-        'cc': ['cc1@example.com', 'cc2@example.com']
-    })
-    params['body'] = params.pop('message')
-    params['to'] = params.pop('recipient_list')
-
-    # test cc exception
-    with pytest.raises(UnsupportedParam):
-        email = EmailMessage(**params)
-        email.send()
-    params.pop('cc')
-
-    # test bcc exception
-    params['bcc'] = ['bcc1@example.com', 'bcc1@example.com']
-    with pytest.raises(UnsupportedParam):
-        email = EmailMessage(**params)
-        email.send()
-    params.pop('bcc')
-
-    if at_least_version('1.8'):  # reply_to is supported from django 1.8
-        # test reply_to exception
-        params['reply_to'] = ['devnull@example.com']
-        with pytest.raises(UnsupportedParam):
-            email = EmailMessage(**params)
-            email.send()
-        params.pop('reply_to')
 
 
 def test_settings_options():

--- a/test/django/test_message.py
+++ b/test/django/test_message.py
@@ -9,6 +9,7 @@ from django.core.mail.message import EmailMessage
 
 from sparkpost.django.exceptions import UnsupportedContent
 from sparkpost.django.message import SparkPostMessage
+from .utils import at_least_version
 
 
 def message(**extras):
@@ -57,20 +58,18 @@ def test_multipart():
     assert multipart_message() == expected
 
 
-def test_cc_bcc_reply_to():
+def test_cc_bcc():
     expected = dict(
         recipients=['recipient@example.com'],
         from_email='test@from.com',
         subject='Test',
         text='Testing',
         cc=['ccone@example.com'],
-        bcc=['bccone@example.com'],
-        reply_to=['replyto@example.com']
+        bcc=['bccone@example.com']
     )
 
     extras = dict(cc=['ccone@example.com'],
-                  bcc=['bccone@example.com'],
-                  reply_to=['replyto@example.com'])
+                  bcc=['bccone@example.com'])
     assert message(**extras) == expected
 
 
@@ -89,3 +88,15 @@ def test_attachment():
 
     with pytest.raises(UnsupportedContent):
         SparkPostMessage(email_message)
+
+if at_least_version('1.8'):
+    def test_reply_to():
+        expected = dict(
+            recipients=['recipient@example.com'],
+            from_email='test@from.com',
+            subject='Test',
+            text='Testing',
+            reply_to=['replyto@example.com']
+        )
+
+        assert message(reply_to=['replyto@example.com']) == expected

--- a/test/django/test_message.py
+++ b/test/django/test_message.py
@@ -81,4 +81,5 @@ if at_least_version('1.8'):
         )
         expected.update(base_expected)
 
-        assert message(reply_to=['replyone@example.com', 'replytwo@example.com']) == expected
+        assert message(reply_to=['replyone@example.com',
+                                 'replytwo@example.com']) == expected

--- a/test/django/test_message.py
+++ b/test/django/test_message.py
@@ -1,0 +1,91 @@
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+import pytest
+from django.core.mail import EmailMultiAlternatives
+from django.core.mail.message import EmailMessage
+
+from sparkpost.django.exceptions import UnsupportedContent
+from sparkpost.django.message import SparkPostMessage
+
+
+def message(**extras):
+    options = dict(
+        subject='Test',
+        body='Testing',
+        from_email='test@from.com',
+        to=['recipient@example.com']
+    )
+    options.update(extras)
+    email_message = EmailMessage(**options)
+    return SparkPostMessage(email_message)
+
+
+def multipart_message(**extras):
+    options = dict(
+        subject='Test',
+        body='Testing',
+        from_email='test@from.com',
+        to=['recipient@example.com']
+    )
+    options.update(extras)
+    email_message = EmailMultiAlternatives(**options)
+    email_message.attach_alternative('<p>Testing</p>', 'text/html')
+    return SparkPostMessage(email_message)
+
+
+def test_minimal():
+    expected = dict(
+        recipients=['recipient@example.com'],
+        from_email='test@from.com',
+        subject='Test',
+        text='Testing'
+    )
+    assert message() == expected
+
+
+def test_multipart():
+    expected = dict(
+        recipients=['recipient@example.com'],
+        from_email='test@from.com',
+        subject='Test',
+        text='Testing',
+        html='<p>Testing</p>'
+    )
+    assert multipart_message() == expected
+
+
+def test_cc_bcc_reply_to():
+    expected = dict(
+        recipients=['recipient@example.com'],
+        from_email='test@from.com',
+        subject='Test',
+        text='Testing',
+        cc=['ccone@example.com'],
+        bcc=['bccone@example.com'],
+        reply_to=['replyto@example.com']
+    )
+
+    extras = dict(cc=['ccone@example.com'],
+                  bcc=['bccone@example.com'],
+                  reply_to=['replyto@example.com'])
+    assert message(**extras) == expected
+
+
+def test_attachment():
+    options = dict(
+        subject='Test',
+        body='Testing',
+        from_email='test@from.com',
+        to=['recipient@example.com']
+    )
+
+    attachment = StringIO()
+    attachment.write('hello file')
+    email_message = EmailMessage(**options)
+    email_message.attach('file.txt', attachment, 'text/plain')
+
+    with pytest.raises(UnsupportedContent):
+        SparkPostMessage(email_message)

--- a/test/django/test_message.py
+++ b/test/django/test_message.py
@@ -77,8 +77,8 @@ def test_attachment():
 if at_least_version('1.8'):
     def test_reply_to():
         expected = dict(
-            reply_to=['replyto@example.com']
+            reply_to='replyone@example.com,replytwo@example.com'
         )
         expected.update(base_expected)
 
-        assert message(reply_to=['replyto@example.com']) == expected
+        assert message(reply_to=['replyone@example.com', 'replytwo@example.com']) == expected

--- a/test/django/utils.py
+++ b/test/django/utils.py
@@ -1,0 +1,7 @@
+from distutils.version import StrictVersion
+
+from django import get_version
+
+
+def at_least_version(version):
+    return StrictVersion(get_version()) > StrictVersion(version)


### PR DESCRIPTION
- Refactored to use a custom message class that just preps data for the API (`SparkPostMessage`)
- Added test utils file for the `at_least_version` function
- Was able to really simplify the backend code - most of the logic lives in the message class now
