### PR TITLE
fix Django backend to correctly base64 encode attachments

### DIFF
--- a/sparkpost/django/message.py
+++ b/sparkpost/django/message.py
@@ -1,4 +1,7 @@
+from base64 import b64encode
+
 from django.core.mail import EmailMultiAlternatives
+from django.conf import settings
 
 from .exceptions import UnsupportedContent
 
@@ -46,11 +49,19 @@ class SparkPostMessage(dict):
 
         if message.attachments:
             formatted['attachments'] = []
+            str_encoding = settings.DEFAULT_CHARSET
             for attachment in message.attachments:
                 filename, content, mimetype = attachment
+                try:
+                    if isinstance(content, unicode):
+                        content = content.encode(str_encoding)
+                except NameError:
+                    if isinstance(content, str):
+                        content = content.encode(str_encoding)
+                base64_encoded_content = b64encode(content)
                 formatted['attachments'].append({
                     'name': filename,
-                    'data': content,
+                    'data': base64_encoded_content.decode('ascii'),
                     'type': mimetype
                 })
 

--- a/sparkpost/transmissions.py
+++ b/sparkpost/transmissions.py
@@ -5,6 +5,12 @@ from email.utils import parseaddr
 from .base import Resource
 
 
+try:
+    string_types = basestring
+except NameError:
+    string_types = str  # Python 3 doesn't have basestring
+
+
 class Transmissions(Resource):
     """
     Transmission class used to send, list and get transmissions. For detailed
@@ -39,7 +45,10 @@ class Transmissions(Resource):
             kwargs.get('use_draft_template', False)
         model['content']['reply_to'] = kwargs.get('reply_to')
         model['content']['subject'] = kwargs.get('subject')
-        model['content']['from'] = kwargs.get('from_email')
+        from_email = kwargs.get('from_email')
+        if isinstance(from_email, string_types):
+            from_email = self._parse_address(from_email)
+        model['content']['from'] = from_email
         model['content']['html'] = kwargs.get('html')
         model['content']['text'] = kwargs.get('text')
         model['content']['template_id'] = kwargs.get('template')
@@ -96,24 +105,22 @@ class Transmissions(Resource):
             encoded_string = base64.b64encode(a_file.read()).decode("ascii")
         return encoded_string
 
+    def _parse_address(self, address):
+        name, email = parseaddr(address)
+        parsed_address = {
+            'email': email
+        }
+        if name:
+            parsed_address['name'] = name
+        return parsed_address
+
     def _extract_recipients(self, recipients):
         formatted_recipients = []
         for recip in recipients:
-            try:
-                string_types = basestring
-            except NameError:
-                string_types = str  # Python 3 doesn't have basestring
             if isinstance(recip, string_types):
-                name, email = parseaddr(recip)
-                formatted_recip = {
-                    'address': {
-                        'name': name,
-                        'email': email
-                    }
-                }
-                if not name:
-                    del formatted_recip['address']['name']
-                formatted_recipients.append(formatted_recip)
+                formatted_recipients.append({
+                    'address': self._parse_address(recip)
+                })
             else:
                 formatted_recipients.append(recip)
         return formatted_recipients

--- a/test/django/test_message.py
+++ b/test/django/test_message.py
@@ -1,8 +1,22 @@
+from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.core.mail.message import EmailMessage
+from django.utils.functional import empty
 
 from sparkpost.django.message import SparkPostMessage
 from .utils import at_least_version
+
+
+def reconfigure_settings(**new_settings):
+    old_settings = settings._wrapped
+
+    settings._wrapped = empty
+    settings.configure(default_settings=old_settings, **new_settings)
+
+
+reconfigure_settings(
+    DEFAULT_CHARSET='utf-8'
+)
 
 
 base_options = dict(
@@ -67,7 +81,25 @@ def test_attachment():
         attachments=[
             {
                 'name': 'file.txt',
-                'data': 'test content',
+                'data': 'dGVzdCBjb250ZW50',
+                'type': 'text/plain'
+            }
+        ]
+    )
+    expected.update(base_expected)
+    assert actual == expected
+
+
+def test_attachment_unicode():
+    email_message = EmailMessage(**base_options)
+    email_message.attach('file.txt', u'test content', 'text/plain')
+
+    actual = SparkPostMessage(email_message)
+    expected = dict(
+        attachments=[
+            {
+                'name': 'file.txt',
+                'data': 'dGVzdCBjb250ZW50',
                 'type': 'text/plain'
             }
         ]


### PR DESCRIPTION
The API spec specifies attachments must be base64 encoded.  This fixes the SparkPostMessage class to actually base64 attachments as well as an invalid test to verify the data is actually encoded property.  This also deals with handling unicode attachments without UnicodeDecodeErrors