### PR TITLE
Handle API errors in SparkPostAPIException

### DIFF
--- a/sparkpost/exceptions.py
+++ b/sparkpost/exceptions.py
@@ -7,7 +7,7 @@ class SparkPostAPIException(SparkPostException):
     def __init__(self, response, *args, **kwargs):
         self.response_status_code = response.status_code
         self.response_error_codes = []
-        if 'application/json' in response.headers['content-type'].lower():
+        if 'application/json' in response.headers.get('content-type','').lower():
           errors = response.json()['errors']
           self.response_error_codes = [e['code'] for e in errors if 'code' in e]
           errors = [e['message'] + ': ' + e.get('description', '')

--- a/sparkpost/exceptions.py
+++ b/sparkpost/exceptions.py
@@ -6,8 +6,10 @@ class SparkPostAPIException(SparkPostException):
     "Handle 4xx and 5xx errors from the SparkPost API"
     def __init__(self, response, *args, **kwargs):
         self.response_status_code = response.status_code
+        self.response_error_codes = []
         if 'application/json' in response.headers['content-type'].lower():
           errors = response.json()['errors']
+          self.response_error_codes = [e['code'] for e in errors if 'code' in e]
           errors = [e['message'] + ': ' + e.get('description', '')
                     for e in errors]
         else:

--- a/sparkpost/exceptions.py
+++ b/sparkpost/exceptions.py
@@ -7,13 +7,15 @@ class SparkPostAPIException(SparkPostException):
     def __init__(self, response, *args, **kwargs):
         self.response_status_code = response.status_code
         self.response_error_codes = []
-        if 'application/json' in response.headers.get('content-type','').lower():
-          errors = response.json()['errors']
-          self.response_error_codes = [e['code'] for e in errors if 'code' in e]
-          errors = [e['message'] + ': ' + e.get('description', '')
-                    for e in errors]
+        content_type = response.headers.get('content-type', '').lower()
+        if 'application/json' in content_type:
+            errors = response.json()['errors']
+            self.response_error_codes = [e['code'] for e in errors
+                                         if 'code' in e]
+            errors = [e['message'] + ': ' + e.get('description', '')
+                      for e in errors]
         else:
-          errors = ['Not available - no JSON response']
+            errors = ['Not available - no JSON response']
         message = """Call to {uri} returned {status_code}, errors:
 
         {errors}

--- a/sparkpost/exceptions.py
+++ b/sparkpost/exceptions.py
@@ -5,9 +5,13 @@ class SparkPostException(Exception):
 class SparkPostAPIException(SparkPostException):
     "Handle 4xx and 5xx errors from the SparkPost API"
     def __init__(self, response, *args, **kwargs):
-        errors = response.json()['errors']
-        errors = [e['message'] + ': ' + e.get('description', '')
-                  for e in errors]
+        self.response_status_code = response.status_code
+        if 'application/json' in response.headers['content-type'].lower():
+          errors = response.json()['errors']
+          errors = [e['message'] + ': ' + e.get('description', '')
+                    for e in errors]
+        else:
+          errors = ['Not available - no JSON response']
         message = """Call to {uri} returned {status_code}, errors:
 
         {errors}


### PR DESCRIPTION
When the API returns 5xx errors, the response typically does not actually include any json, which causes JSONDecodeErrors to be raised by `response.json()`.  This branch addresses that issue by only parsing the response as json if the content-type response header is set correctly.

Additionally, it sets `response_status_code` and `response_errors_codes` on the SparkPostAPIException so that applications can catch the exception and react accordingly.  5xx errors should usually be retried, while 4xx errors sometimes should be retried (rate limit) and other times be fatal (recipient on suppression list).