### PR TITLE
Transmissions: inline_images should not be set by default in content

### DIFF
--- a/sparkpost/transmissions.py
+++ b/sparkpost/transmissions.py
@@ -78,9 +78,10 @@ class Transmissions(Resource):
         model['content']['attachments'] = self._extract_attachments(
             attachments)
 
-        inline_images = kwargs.get('inline_images', [])
-        model['content']['inline_images'] = self._extract_attachments(
-            inline_images)
+        if 'inline_images' in kwargs:
+            inline_images = kwargs['inline_images']
+            model['content']['inline_images'] = self._extract_attachments(
+                inline_images)
 
         return model
 


### PR DESCRIPTION
For example if message contains no html, an exception is raised : 
````
SparkPostAPIException: Call to https://api.sparkpost.com/api/v1/transmissions 
returned 422, errors:
  required field is missing: content.inline_images requires content.html
````