### PR TITLE
Fix empty inline_images bug

### DIFF
--- a/sparkpost/transmissions.py
+++ b/sparkpost/transmissions.py
@@ -79,8 +79,9 @@ class Transmissions(Resource):
             attachments)
 
         inline_images = kwargs.get('inline_images', [])
-        model['content']['inline_images'] = self._extract_attachments(
-            inline_images)
+        if inline_images:
+            model['content']['inline_images'] = self._extract_attachments(
+                inline_images)
 
         return model
 


### PR DESCRIPTION
I'm not sure how to write a proper test for this one. It looks like it's more of an API endpoint bug -- it should treat an empty list as an empty value.