### PR TITLE
SparkPostCeleryEmailBackend for Django

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ wheel
 twine
 Django>=1.7,<1.10
 tornado>=3.2
+celery>=3.1.23

--- a/sparkpost/django/email_backend.py
+++ b/sparkpost/django/email_backend.py
@@ -44,6 +44,7 @@ class SparkPostCeleryEmailBackend(SparkPostEmailBackend):
     def send_messages(self, email_messages):
         """
         Send emails, returns celery result object (AsyncResult)
-        When task will be complete, it will contain integer representing number of successful emails
+        When task will be complete, it will contain integer
+        representing number of successful emails
         """
         return send_messages.delay(self, email_messages)

--- a/sparkpost/django/email_backend.py
+++ b/sparkpost/django/email_backend.py
@@ -4,6 +4,7 @@ from django.core.mail.backends.base import BaseEmailBackend
 from sparkpost import SparkPost
 
 from .message import SparkPostMessage
+from .tasks import send_messages
 
 
 class SparkPostEmailBackend(BaseEmailBackend):
@@ -37,3 +38,12 @@ class SparkPostEmailBackend(BaseEmailBackend):
         params = getattr(settings, 'SPARKPOST_OPTIONS', {}).copy()
         params.update(message)
         return self.client.transmissions.send(**params)
+
+
+class SparkPostCeleryEmailBackend(SparkPostEmailBackend):
+    def send_messages(self, email_messages):
+        """
+        Send emails, returns celery result object (AsyncResult)
+        When task will be complete, it will contain integer representing number of successful emails
+        """
+        return send_messages.delay(self, email_messages)

--- a/sparkpost/django/tasks.py
+++ b/sparkpost/django/tasks.py
@@ -9,9 +9,11 @@ def send_messages(obj, email_messages):
     """
     Celery task for 'send_messages' EmailBackend method.
     It sends all email messages in parallel via 'send_message' task,
-    and then it reduces all results via `send_summary` task (celery chord is convenient)
+    and then it reduces all results via `send_summary` task
+    (celery chord is convenient)
     """
-    return chord(send_message.s(obj, email_message) for email_message in email_messages)(send_summary.s())
+    return chord(send_message.s(obj, email_message)
+                 for email_message in email_messages)(send_summary.s())
 
 
 @task()

--- a/sparkpost/django/tasks.py
+++ b/sparkpost/django/tasks.py
@@ -1,6 +1,8 @@
 from celery import chord
 from celery.task import task
 
+from .message import SparkPostMessage
+
 
 @task()
 def send_messages(obj, email_messages):
@@ -10,7 +12,7 @@ def send_messages(obj, email_messages):
 @task()
 def send_message(obj, message):
     try:
-        response = obj._send(message)
+        response = obj._send(SparkPostMessage(message))
     except Exception:
         if not obj.fail_silently:
             raise

--- a/sparkpost/django/tasks.py
+++ b/sparkpost/django/tasks.py
@@ -1,0 +1,23 @@
+from celery import chord
+from celery.task import task
+
+
+@task()
+def send_messages(obj, email_messages):
+    return chord(send_message.s(obj, email_message) for email_message in email_messages)(send_summary.s())
+
+
+@task()
+def send_message(obj, message):
+    try:
+        response = obj._send(message)
+    except Exception:
+        if not obj.fail_silently:
+            raise
+    else:
+        return response['total_accepted_recipients']
+
+
+@task()
+def send_summary(send_results):
+    return sum([send_result.result for send_result in send_results])

--- a/sparkpost/django/tasks.py
+++ b/sparkpost/django/tasks.py
@@ -6,6 +6,11 @@ from .message import SparkPostMessage
 
 @task()
 def send_messages(obj, email_messages):
+    """
+    Celery task for 'send_messages' EmailBackend method.
+    It sends all email messages in parallel via 'send_message' task,
+    and then it reduces all results via `send_summary` task (celery chord is convenient)
+    """
     return chord(send_message.s(obj, email_message) for email_message in email_messages)(send_summary.s())
 
 

--- a/sparkpost/django/tasks.py
+++ b/sparkpost/django/tasks.py
@@ -22,4 +22,4 @@ def send_message(obj, message):
 
 @task()
 def send_summary(send_results):
-    return sum([send_result.result for send_result in send_results])
+    return sum([send_result for send_result in send_results])

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34}-django{17,18}, py35-django{18,19}
+envlist = {py27,py34}-django{17,18}-celery, py35-django{18,19}-celery
 
 [testenv]
 deps =
@@ -7,10 +7,11 @@ deps =
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
+    celery: celery==3.1.23
 
 commands = py.test test/
 
-[testenv:py35-django19]
+[testenv:py35-django19-celery]
 
 commands =
     flake8 sparkpost test


### PR DESCRIPTION
Hi there!
Until recent times, I used Mandrill to send emails in Django projects. When I started migrating to Sparkpost I found there is no implemented way in python-sparkpost to send emails asynchronously using Celery. For example, I used `djrillcelery` pypi package for it when I used Mandrill, and it worked well.
I implemented this feature and there is my pull request. How you could use it:

Set up settings.py:

```python
# New email backend
EMAIL_BACKEND = 'sparkpost.django.email_backend.SparkPostCeleryEmailBackend'

# Also you must include sparkpost in `INSTALLED_APPS`, it needs for celery tasks:
INSTALLED_APPS = (
    ...
    'sparkpost.django',
    ...
)
```

And now you can send email using usual way:
```python
from django.core.mail import send_mail

r = send_mail('Subject', 'Hello from celery', 'sender@example.com', ['to1@example.com', 'to2@example.com', ])
```

`r` is Celery `AsyncResult` object returned by `send_messages` task
`r.result` is AsyncResult object for chord of `send_message` tasks
`r.result.result` is integer number of successful emails returned by `send_summary` task, it will be non-zero when all tasks will be completed and when `r.result.successful()` will be True

You can wait for final result, but in absolutely most cases I'm not waiting for results of email sending.

I installed my fork for one of my projects, and it works. I could not write tests for it, I don't know pytest.