### PR TITLE
Issue #107 -Django backend unable to use templates, substitution_data

### DIFF
--- a/docs/django/backend.rst
+++ b/docs/django/backend.rst
@@ -44,7 +44,26 @@ Django is now configured to use the SparkPost email backend. You can now send ma
         html_message='<p>Hello Rock stars!</p>',
     )
 
-If you need to add cc, bcc, reply to, or attachments, use the `EmailMultiAlternatives` class directly:
+                     
+You can also use `EmailMessage` or `EmailMultiAlternatives` class directly. That will give you access to more specific fileds like `template`:
+
+.. code-block:: python
+    
+    email = EmailMessage(
+        to=[
+            {
+                "address": "to@example.com",
+                "substitution_data": {
+                    "key": "value"
+                }
+            }
+        ],
+        from_email='test@from.com'
+    )
+    email.template = 'template-id'
+    email.send()
+
+Or cc, bcc, reply to, or attachments fields:
 
 .. code-block:: python
 

--- a/sparkpost/django/message.py
+++ b/sparkpost/django/message.py
@@ -22,12 +22,20 @@ class SparkPostMessage(dict):
     """
 
     def __init__(self, message):
-        formatted = {
-            'recipients': message.to,
-            'from_email': message.from_email,
-            'subject': message.subject,
-            'text': message.body
-        }
+
+        formatted = dict()
+
+        if message.to:
+            formatted['recipients'] = message.to
+
+        if message.from_email:
+            formatted['from_email'] = message.from_email
+
+        if message.subject:
+            formatted['subject'] = message.subject
+
+        if message.body:
+            formatted['text'] = message.body
 
         if message.cc:
             formatted['cc'] = message.cc
@@ -64,5 +72,10 @@ class SparkPostMessage(dict):
                     'data': base64_encoded_content.decode('ascii'),
                     'type': mimetype
                 })
+        if hasattr(message, 'substitution_data'):
+            formatted['substitution_data'] = message.substitution_data
+
+        if hasattr(message, 'template'):
+            formatted['template'] = message.template
 
         super(SparkPostMessage, self).__init__(formatted)

--- a/test/django/test_message.py
+++ b/test/django/test_message.py
@@ -107,6 +107,55 @@ def test_attachment_unicode():
     expected.update(base_expected)
     assert actual == expected
 
+
+def test_template():
+    email_message = EmailMessage(
+        to=['to@example.com'],
+        from_email='test@from.com'
+    )
+    email_message.template = 'template-id'
+    actual = SparkPostMessage(email_message)
+    expected = dict(
+        recipients=['to@example.com'],
+        from_email='test@from.com',
+        template='template-id'
+    )
+    assert actual == expected
+
+
+def test_substitution_data():
+    email_message = EmailMessage(
+        to=[
+            {
+                "address": "to@example.com",
+                "substitution_data": {
+                    "key": "value"
+                }
+            }
+        ],
+        from_email='test@from.com'
+    )
+    email_message.template = 'template-id'
+    email_message.substitution_data = {"key2": "value2"}
+    actual = SparkPostMessage(email_message)
+
+    expected = dict(
+        recipients=[
+            {
+                "address": "to@example.com",
+                "substitution_data": {
+                    "key": "value"
+                }
+            }
+        ],
+        from_email='test@from.com',
+        template='template-id',
+        substitution_data={"key2": "value2"}
+    )
+
+    assert actual == expected
+
+
 if at_least_version('1.8'):
     def test_reply_to():
         expected = dict(


### PR DESCRIPTION
changed SparkPostMessage class __init__ method so those parameters will be accepted now.