### PR TITLE
guess attachment mimetype in Django email backend if not provided

### DIFF
--- a/sparkpost/django/message.py
+++ b/sparkpost/django/message.py
@@ -1,3 +1,4 @@
+import mimetypes
 from base64 import b64encode
 
 from django.core.mail import EmailMultiAlternatives
@@ -63,6 +64,10 @@ class SparkPostMessage(dict):
             str_encoding = settings.DEFAULT_CHARSET
             for attachment in message.attachments:
                 filename, content, mimetype = attachment
+
+                if mimetype is None:
+                    mimetype, _ = mimetypes.guess_type(filename)
+
                 try:
                     if isinstance(content, unicode):
                         content = content.encode(str_encoding)

--- a/sparkpost/django/message.py
+++ b/sparkpost/django/message.py
@@ -2,6 +2,7 @@ import mimetypes
 from base64 import b64encode
 
 from django.core.mail import EmailMultiAlternatives
+from django.core.mail.message import DEFAULT_ATTACHMENT_MIME_TYPE
 from django.conf import settings
 
 from .exceptions import UnsupportedContent
@@ -67,6 +68,8 @@ class SparkPostMessage(dict):
 
                 if mimetype is None:
                     mimetype, _ = mimetypes.guess_type(filename)
+                    if mimetype is None:
+                        mimetype = DEFAULT_ATTACHMENT_MIME_TYPE
 
                 try:
                     if isinstance(content, unicode):

--- a/test/django/test_message.py
+++ b/test/django/test_message.py
@@ -108,6 +108,24 @@ def test_attachment_unicode():
     assert actual == expected
 
 
+def test_attachment_no_mimetype():
+    email_message = EmailMessage(**base_options)
+    email_message.attach('file.txt', 'test content')
+
+    actual = SparkPostMessage(email_message)
+    expected = dict(
+        attachments=[
+            {
+                'name': 'file.txt',
+                'data': 'dGVzdCBjb250ZW50',
+                'type': 'text/plain'
+            }
+        ]
+    )
+    expected.update(base_expected)
+    assert actual == expected
+
+
 def test_content_subtype():
     email_message = EmailMessage(
         to=['to@example.com'],

--- a/test/django/test_message.py
+++ b/test/django/test_message.py
@@ -108,7 +108,7 @@ def test_attachment_unicode():
     assert actual == expected
 
 
-def test_attachment_no_mimetype():
+def test_attachment_guess_mimetype():
     email_message = EmailMessage(**base_options)
     email_message.attach('file.txt', 'test content')
 
@@ -119,6 +119,24 @@ def test_attachment_no_mimetype():
                 'name': 'file.txt',
                 'data': 'dGVzdCBjb250ZW50',
                 'type': 'text/plain'
+            }
+        ]
+    )
+    expected.update(base_expected)
+    assert actual == expected
+
+
+def test_attachment_guess_mimetype_fallback():
+    email_message = EmailMessage(**base_options)
+    email_message.attach('file', 'test content')
+
+    actual = SparkPostMessage(email_message)
+    expected = dict(
+        attachments=[
+            {
+                'name': 'file',
+                'data': 'dGVzdCBjb250ZW50',
+                'type': 'application/octet-stream'
             }
         ]
     )


### PR DESCRIPTION
Hello,

This is an issue I ran into while using [django-post-office](https://github.com/ui/django-post_office). The django `EmailMessage.attach` method does not require you to submit a mimetype, stating that it is [guessed if not provided](https://github.com/django/django/blob/master/django/core/mail/message.py#L303). Unfortunately the django-post-office API does not support specifying a mime type, meaning I have no choice but to rely on the guessing mechanism. Long story short, I cannot currently attach any files to my emails.

The email backend would normally let the EmailMessage class do this when converting the email to MIME format (see the `EmailMessage.message` [method](https://github.com/django/django/blob/master/django/core/mail/message.py#L259) which eventually calls [EmailMessage._create_attachment](https://github.com/django/django/blob/master/django/core/mail/message.py#L396)). Obviously the sparkpost backend does not call any of this code.

I've duplicated django's method of guessing the mimetype into the sparkpost backend. I've also added two tests to demonstrate the problem.