### PR TITLE
Make RequestsTransport use a requests session

### DIFF
--- a/sparkpost/base.py
+++ b/sparkpost/base.py
@@ -4,9 +4,12 @@ from .exceptions import SparkPostAPIException
 
 
 class RequestsTransport(object):
-    def request(self, method, uri, headers, **kwargs):
+    def __init__(self):
         import requests
-        response = requests.request(method, uri, headers=headers, **kwargs)
+        self.sess = requests.Session()
+
+    def request(self, method, uri, headers, **kwargs):
+        response = self.sess.request(method, uri, headers=headers, **kwargs)
         if response.status_code == 204:
             return True
         if not response.ok:


### PR DESCRIPTION
Requests will utilise HTTP Keep-Alive if multiple requests to the same hostname are within a 'Session' object. 

Source: http://docs.python-requests.org/en/master/user/advanced/
"Excellent news — thanks to urllib3, keep-alive is 100% automatic within a session! Any requests that you make within a session will automatically reuse the appropriate connection!"

This change makes the RequestsTransport open a session and reuse it for future requests. On our tests this gives significantly better throughput as a TCP / SSL  connection is not opened for each request.