### PR TITLE
Dealing with non ascii chars from the body and subdata

### DIFF
--- a/sparkpost/transmissions.py
+++ b/sparkpost/transmissions.py
@@ -245,7 +245,8 @@ class Transmissions(Resource):
         """
 
         payload = self._translate_keys(**kwargs)
-        results = self.request('POST', self.uri, data=json.dumps(payload))
+        data = json.dumps(payload, ensure_ascii=False).encode('utf-8')
+        results = self.request('POST', self.uri, data=data)
         return results
 
     def _fetch_get(self, transmission_id):

--- a/test/test_transmissions.py
+++ b/test/test_transmissions.py
@@ -343,7 +343,7 @@ def test_fail_delete():
 
 
 @responses.activate
-def test_json_serialize_with_a_non_ascii_unicode():
+def test_json_serialize_with_a_non_ascii_unicode_from_substitution_data():
     responses.add(
         responses.POST,
         'https://api.sparkpost.com/api/v1/transmissions',
@@ -362,9 +362,28 @@ def test_json_serialize_with_a_non_ascii_unicode():
         'address': {'email': 'unicode_email@example.com'},
         'substitution_data': {'name': u'😄'}
     }])
+    assert results == 'yay'
 
     results = sp.transmission.send(recipients=[{
         'address': {'email': 'unicode_email@example.com'},
         'substitution_data': {'name': u'漢字'}
+    }])
+    assert results == 'yay'
+
+
+@responses.activate
+def test_json_serialize_with_a_non_ascii_unicode_from_body():
+    responses.add(
+        responses.POST,
+        'https://api.sparkpost.com/api/v1/transmissions',
+        status=200,
+        content_type='application/json',
+        body='{"results": "yay"}'
+    )
+    sp = SparkPost('fake-key')
+    results = sp.transmission.send(recipients=[{
+        'address': {'email': 'unicode_email@example.com'},
+        'substitution_data': {'name': u'João 漢字'},
+        'text': u'Hello!!! 😄 my name is {{ name }}'
     }])
     assert results == 'yay'

--- a/test/test_transmissions.py
+++ b/test/test_transmissions.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 import base64
 import json
 import os
@@ -339,3 +340,31 @@ def test_fail_delete():
     with pytest.raises(SparkPostAPIException):
         sp = SparkPost('fake-key')
         sp.transmission.delete('foobar')
+
+
+@responses.activate
+def test_json_serialize_with_a_non_ascii_unicode():
+    responses.add(
+        responses.POST,
+        'https://api.sparkpost.com/api/v1/transmissions',
+        status=200,
+        content_type='application/json',
+        body='{"results": "yay"}'
+    )
+    sp = SparkPost('fake-key')
+    results = sp.transmission.send(recipients=[{
+        'address': {'email': 'unicode_email@example.com'},
+        'substitution_data': {'name': u'João'}
+    }])
+    assert results == 'yay'
+
+    results = sp.transmission.send(recipients=[{
+        'address': {'email': 'unicode_email@example.com'},
+        'substitution_data': {'name': u'😄'}
+    }])
+
+    results = sp.transmission.send(recipients=[{
+        'address': {'email': 'unicode_email@example.com'},
+        'substitution_data': {'name': u'漢字'}
+    }])
+    assert results == 'yay'


### PR DESCRIPTION
Adding an encode('utf-8') in the end of the json generated string may help.