### PR TITLE
Tweaks to exception handling

### DIFF
--- a/sparkpost/exceptions.py
+++ b/sparkpost/exceptions.py
@@ -8,7 +8,7 @@ class SparkPostAPIException(SparkPostException):
         try:
             errors = response.json()['errors']
             error_template = "{message} Code: {code} Description: {desc} \n"
-            errors = [error_template.format(message=e['message'],
+            errors = [error_template.format(message=e.get('message', ''),
                                             code=e.get('code', 'none'),
                                             desc=e.get('description', 'none'))
                       for e in errors]

--- a/sparkpost/exceptions.py
+++ b/sparkpost/exceptions.py
@@ -8,14 +8,12 @@ class SparkPostAPIException(SparkPostException):
         errors = None
         try:
             errors = response.json()['errors']
-            errors = [e['message'] +
-                      ' Code: ' + e.get('code', '') +
-                      ' Description: ' + e.get('description', '') +
-                      '\n'
+            error_template = "{message} Code: {code} Description: {desc} \n"
+            errors = [error_template.format(message=e['message'],
+                                            code=e.get('code', 'none'),
+                                            desc=e.get('description', 'none'))
                       for e in errors]
-        except:
-            pass
-        if not errors:
+        except ValueError:
             errors = [response.text or ""]
         self.status = response.status_code
         self.response = response

--- a/sparkpost/exceptions.py
+++ b/sparkpost/exceptions.py
@@ -5,7 +5,6 @@ class SparkPostException(Exception):
 class SparkPostAPIException(SparkPostException):
     "Handle 4xx and 5xx errors from the SparkPost API"
     def __init__(self, response, *args, **kwargs):
-        errors = None
         try:
             errors = response.json()['errors']
             error_template = "{message} Code: {code} Description: {desc} \n"
@@ -13,7 +12,7 @@ class SparkPostAPIException(SparkPostException):
                                             code=e.get('code', 'none'),
                                             desc=e.get('description', 'none'))
                       for e in errors]
-        except ValueError:
+        except:
             errors = [response.text or ""]
         self.status = response.status_code
         self.response = response

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -92,6 +92,20 @@ def test_fail_nojson_request():
         resource.request('GET', resource.uri)
 
 
+@responses.activate
+def test_fail_no_errors():
+    responses.add(
+        responses.GET,
+        fake_uri,
+        status=500,
+        content_type='application/json',
+        body='no errors'
+    )
+    resource = create_resource()
+    with pytest.raises(SparkPostAPIException):
+        resource.request('GET', resource.uri)
+
+
 def test_fail_get():
     resource = create_resource()
     with pytest.raises(NotImplementedError):

--- a/test/test_transmissions.py
+++ b/test/test_transmissions.py
@@ -333,7 +333,7 @@ def test_fail_delete():
         content_type='application/json',
         body="""
         {"errors": [{"message": "resource not found",
-            "description": "Resource not found:transmission id foobar""}]}
+            "description": "Resource not found:transmission id foobar"}]}
         """
     )
     with pytest.raises(SparkPostAPIException):


### PR DESCRIPTION
This PR does a few things:

* Fixes an issue reported in #134 related to handling of the error responses:

```
Traceback (most recent call last):
  File "send_transmission.py", line 19, in <module>
    campaign='python-sparkpost example',
  File "/Users/rleland/src/oss/python-sparkpost/sparkpost/transmissions.py", line 248, in send
    results = self.request('POST', self.uri, data=json.dumps(payload))
  File "/Users/rleland/src/oss/python-sparkpost/sparkpost/base.py", line 41, in request
    **kwargs)
  File "/Users/rleland/src/oss/python-sparkpost/sparkpost/base.py", line 16, in request
    raise SparkPostAPIException(response)
  File "/Users/rleland/src/oss/python-sparkpost/sparkpost/exceptions.py", line 30, in __init__
    errors='\n'.join(errors)
TypeError: sequence item 0: expected string, dict found
```

This was caused because of how we were constructing the message. Error code, when present, would be parsed as an int, and didn't work with concatenation. I modified it to use string formatting.

* Intercepts when there is an issue parsing the JSON, passing back the repsonse body as the error message
* Fixes an error in a transmissions test
* Adds a test for a response that contains no JSON