### PR TITLE
Update SparkPostMessage to support campaign

### DIFF
--- a/sparkpost/django/message.py
+++ b/sparkpost/django/message.py
@@ -87,4 +87,7 @@ class SparkPostMessage(dict):
         if hasattr(message, 'substitution_data'):
             formatted['substitution_data'] = message.substitution_data
 
+        if hasattr(message, 'campaign'):
+            formatted['campaign'] = message.campaign
+
         super(SparkPostMessage, self).__init__(formatted)

--- a/test/django/test_message.py
+++ b/test/django/test_message.py
@@ -175,6 +175,17 @@ def test_template():
     assert actual == expected
 
 
+def test_campaign():
+    email_message = EmailMessage(**base_options)
+    email_message.campaign = 'campaign-id'
+    actual = SparkPostMessage(email_message)
+    expected = dict(
+        campaign='campaign-id'
+    )
+    expected.update(base_expected)
+    assert actual == expected
+
+
 def test_substitution_data():
     email_message = EmailMessage(
         to=[


### PR DESCRIPTION
Updates sending a Django `EmailMessage` to support a `campaign` attribute. Also adds a test to verify.

Closes #136

