### PR TITLE
Allow passing of subaccount

### DIFF
--- a/sparkpost/base.py
+++ b/sparkpost/base.py
@@ -32,10 +32,12 @@ class Resource(object):
         return "%s/%s" % (self.base_uri, self.key)
 
     def request(self, method, uri, **kwargs):
+        subaccount = kwargs.pop('subaccount', 0)
         headers = {
             'User-Agent': 'python-sparkpost/' + sparkpost.__version__,
             'Content-Type': 'application/json',
-            'Authorization': self.api_key
+            'Authorization': self.api_key,
+            'X-MSYS-SUBACCOUNT': subaccount
         }
         response = self.transport.request(method, uri, headers=headers,
                                           **kwargs)

--- a/sparkpost/transmissions.py
+++ b/sparkpost/transmissions.py
@@ -251,15 +251,18 @@ class Transmissions(Resource):
         """
 
         payload = self._translate_keys(**kwargs)
-        results = self.request('POST', self.uri, data=json.dumps(payload))
+        subaccount = kwargs.pop('subaccount', 0)
+        results = self.request('POST', self.uri, data=json.dumps(payload),
+                               subaccount=subaccount)
         return results
 
-    def _fetch_get(self, transmission_id):
+    def _fetch_get(self, transmission_id, **kwargs):
         uri = "%s/%s" % (self.uri, transmission_id)
-        results = self.request('GET', uri)
+        subaccount = kwargs.pop('subaccount', 0)
+        results = self.request('GET', uri, subaccount=subaccount)
         return results
 
-    def get(self, transmission_id):
+    def get(self, transmission_id, **kwargs):
         """
         Get a transmission by ID
 
@@ -268,7 +271,7 @@ class Transmissions(Resource):
         :returns: the requested transmission if found
         :raises: :exc:`SparkPostAPIException` if transmission is not found
         """
-        results = self._fetch_get(transmission_id)
+        results = self._fetch_get(transmission_id, **kwargs)
         return results['transmission']
 
     def list(self, **kwargs):
@@ -285,9 +288,11 @@ class Transmissions(Resource):
         'check https://sparkpo.st/5qcj4.'
 
         warnings.warn(warn_msg, DeprecationWarning)
-        return self.request('GET', self.uri, params=kwargs)
+        subaccount = kwargs.pop('subaccount', 0)
+        return self.request('GET', self.uri, params=kwargs,
+                            subaccount=subaccount)
 
-    def delete(self, transmission_id):
+    def delete(self, transmission_id, **kwargs):
         """
         Delete a transmission by ID
 
@@ -298,5 +303,6 @@ class Transmissions(Resource):
             or Canceled
         """
         uri = "%s/%s" % (self.uri, transmission_id)
-        results = self.request('DELETE', uri)
+        subaccount = kwargs.pop('subaccount', 0)
+        results = self.request('DELETE', uri, subaccount=subaccount)
         return results


### PR DESCRIPTION
WORK IN PROGRESS - DO NOT MERGE

Refs #150. This work extracts `subaccount` from the `kwargs`, but I'm not liking how it's the same chunk of code everywhere. The base resource modifications are simple, but passing in subaccount optionally per call, coupled with the subclassing/API design we've set up means we have to allow `subaccount` to be extracted/passed through on all subclass requesting methods, which is meh.

We could put a method on the base class like `extract_subaccount`, but when we pass around `kwargs` and do a `pop` it's operating on a scoped copy within that method (I tried it) and not the `kwarg`s we passed in. I tried it, but maybe I'm doing something wrong.

Requires some more thought. Additionally with the 2.x implementation under way, we might consider abandoning this as users can instantiate multiple copies of the lib with subaccount API keys.

Comments welcome.