### PR TITLE
Support for EmailMessage.extra_headers and transactional option

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,4 +21,5 @@ Patches and suggestions
 - `@gnarvaja <https://github.com/gnarvaja>`_
 - `@pegler <https://github.com/pegler>`_
 - `@puttu <https://github.com/puttu>`_
+- Janusz Skonieczny `@wooyek <https://github.com/wooyek>`_
 - ADD YOURSELF HERE (and link to your github page)

--- a/sparkpost/django/message.py
+++ b/sparkpost/django/message.py
@@ -90,4 +90,12 @@ class SparkPostMessage(dict):
         if hasattr(message, 'campaign'):
             formatted['campaign'] = message.campaign
 
+        if message.extra_headers:
+            formatted['custom_headers'] = message.extra_headers
+            if 'X-MSYS-API' in message.extra_headers:
+                import json
+                msys_api = json.loads(message.extra_headers['X-MSYS-API'])
+                if msys_api and msys_api.get('options', {}).get('transactional', False):  # noqa: E501
+                    formatted['transactional'] = True
+
         super(SparkPostMessage, self).__init__(formatted)

--- a/test/django/test_message.py
+++ b/test/django/test_message.py
@@ -228,3 +228,30 @@ if at_least_version('1.8'):
 
         assert message(reply_to=['replyone@example.com',
                                  'replytwo@example.com']) == expected
+
+
+def test_extra_headers():
+    email_message = EmailMessage(**base_options)
+    email_message.extra_headers['FOO'] = 'bar'
+
+    actual = SparkPostMessage(email_message)
+    expected = dict(
+        custom_headers={'FOO': 'bar'},
+    )
+    expected.update(base_expected)
+    assert actual == expected
+
+
+def test_transactional():
+    email_message = EmailMessage(**base_options)
+    import json
+    msys_api = json.dumps({'options': {'transactional': True}})
+    email_message.extra_headers['X-MSYS-API'] = msys_api
+
+    actual = SparkPostMessage(email_message)
+    expected = dict(
+        custom_headers={'X-MSYS-API': msys_api},
+        transactional=True,
+    )
+    expected.update(base_expected)
+    assert actual == expected


### PR DESCRIPTION
Relates to SparkPost/python-sparkpost#159

EmailMessage.extra_headers land in custom_headers transmission param,
and X-MSYS-API if present and has options.transactional == True will
translate onto transactional transmission param.