### PR TITLE
Support for Metadata in SparkPost Django Email Backend

### DIFF
--- a/docs/django/backend.rst
+++ b/docs/django/backend.rst
@@ -44,11 +44,11 @@ Django is now configured to use the SparkPost email backend. You can now send ma
         html_message='<p>Hello Rock stars!</p>',
     )
 
-                     
+
 You can also use `EmailMessage` or `EmailMultiAlternatives` class directly. That will give you access to more specific fileds like `template`:
 
 .. code-block:: python
-    
+
     email = EmailMessage(
         to=[
             {
@@ -81,6 +81,60 @@ Or cc, bcc, reply to, or attachments fields:
 
     email.attach_alternative('<p>Woo hoo! Sent from Django!</p>', 'text/html')
     email.attach('image.png', img_data, 'image/png')
+    email.send()
+
+Metadata Email Sending (new as of July 31, 2018)
+------------------------------------------------
+
+If you are trying to attach metadata for SparkPost webhook usage, you need to use `EmailMessageWithMetadata` or `EmailMultiAlternativesWithMetadata` class directly. That will give you access to more specific fileds like `template`:
+
+.. code-block:: python
+
+    from sparkpostfrom sparkpost.django.message import EmailMessageWithMetadata
+
+    email = EmailMessageWithMetadata(
+        to=[
+            {
+                "address": "to@example.com",
+                "substitution_data": {
+                    "key": "value"
+                }
+            }
+        ],
+        from_email='test@from.com',
+        metadata={'key1': 'value1'}
+    )
+    email.template = 'template-id'
+
+    # Add more metadata
+    email.metadata['key2': 'value2']
+
+    email.send()
+
+
+Or cc, bcc, reply to, or attachments fields:
+
+.. code-block:: python
+
+    from sparkpostfrom sparkpost.django.message import EmailMultiAlternativesWithMetadata
+
+    email = EmailMultiAlternatives(
+      subject='hello from sparkpost',
+      body='Woo hoo! Sent from Django!',
+      from_email='from@yourdomain.com',
+      to=['to@example.com'],
+      cc=['ccone@example.com'],
+      bcc=['bccone@example.com'],
+      reply_to=['replyone@example.com'],
+      metadata={'key1': 'value1'}
+    )
+
+    email.attach_alternative('<p>Woo hoo! Sent from Django!</p>', 'text/html')
+    email.attach('image.png', img_data, 'image/png')
+
+    # Add more metadata if we want
+    email.metadata['key2': 'value2']
+
     email.send()
 
 

--- a/docs/django/backend.rst
+++ b/docs/django/backend.rst
@@ -90,7 +90,7 @@ If you are trying to attach metadata for SparkPost webhook usage, you need to us
 
 .. code-block:: python
 
-    from sparkpostfrom sparkpost.django.message import EmailMessageWithMetadata
+    from sparkpost.django.message import EmailMessageWithMetadata
 
     email = EmailMessageWithMetadata(
         to=[
@@ -116,7 +116,7 @@ Or cc, bcc, reply to, or attachments fields:
 
 .. code-block:: python
 
-    from sparkpostfrom sparkpost.django.message import EmailMultiAlternativesWithMetadata
+    from sparkpost.django.message import EmailMultiAlternativesWithMetadata
 
     email = EmailMultiAlternatives(
       subject='hello from sparkpost',

--- a/examples/django/send_email_with_metadata.py
+++ b/examples/django/send_email_with_metadata.py
@@ -1,0 +1,53 @@
+from sparkpost.django.message import EmailMessageWithMetadata, \
+    EmailMultiAlternativesWithMetadata
+
+
+def send_django_email_with_metadata():
+    """
+    Make sure you setup your Django Email Backend before trying these examples:
+    https://github.com/SparkPost/python-sparkpost/blob/master/docs/django/backend.rst
+
+    EmailMessageWithMetadata is just a simple update to Django's EmailMessage
+    (https://docs.djangoproject.com/en/2.0/topics/email/#django.core.mail.EmailMessage)
+    Which adds a metadata field. The metadata can be sent back to you in
+    webhook POSTs from SparkPost. Without these classes, The SparkPost Django
+    email backend will not be able to send metadata with the email.
+    """
+
+    email = EmailMessageWithMetadata(
+        'Hello',
+        'Body goes here',
+        'from@example.com',
+        ['to1@example.com', 'to2@example.com'],
+        ['bcc@example.com'],
+        reply_to=['another@example.com'],
+        headers={'Message-ID': 'foo'},
+        metadata={'some_metadata': 'that you want'}
+    )
+
+    email.metadata['more_metadata'] = 'true'
+
+    email.send(fail_silently=False)
+
+
+def send_django_email_alternatives_with_metadata():
+    """
+    Same as send_django_email_with_metadata(), but using
+    EmailMultiAlternativesWithMetadata. See send_django_email_with_metadata()
+    doc string for more details
+    """
+    email = EmailMultiAlternativesWithMetadata(
+        'Hello',
+        'Body goes here',
+        'from@example.com',
+        ['to1@example.com', 'to2@example.com'],
+        ['bcc@example.com'],
+        reply_to=['another@example.com'],
+        headers={'Message-ID': 'foo'},)
+
+    email.metadata['more_metadata'] = 'true'
+
+    html_content = '<p>This is an <strong>important</strong> message.</p>'
+    email.attach_alternative(html_content, "text/html")
+
+    email.send(fail_silently=False)


### PR DESCRIPTION
Turns out the SparkPost Django Email Backend did not support sending metadata via the transmission API. I've added support for sending email with metadata and added documentation to docs/django/backend.rst. I've also created some example code in examples/django/send_email_with_metadata.py

Implementation of issue #175. 