### PR TITLE
Support Metadata without additional classes

### DIFF
--- a/docs/django/backend.rst
+++ b/docs/django/backend.rst
@@ -47,23 +47,28 @@ Django is now configured to use the SparkPost email backend. You can now send ma
         html_message='<p>Hello Rock stars!</p>',
     )
 
-                     
-You can also use `EmailMessage` or `EmailMultiAlternatives` class directly. That will give you access to more specific fileds like `template`:
+
+You can also use `EmailMessage` or `EmailMultiAlternatives` class directly.
+This allows you to set additional SparkPost fields: `template`, `substitution_data`, `campaign`, `metadata`:
 
 .. code-block:: python
-    
+
     email = EmailMessage(
         to=[
             {
-                "address": "to@example.com",
-                "substitution_data": {
-                    "key": "value"
-                }
+                'address': 'to@example.com',
+                'substitution_data': {
+                    'reward-level': 'Silver'
+                },
+                'metadata': {'user-id': '46576432465'}
             }
         ],
         from_email='test@from.com'
     )
     email.template = 'template-id'
+    email.substitution_data = {'season': 'Winter'}
+    email.metadata = {'cart-id': '74562657874'}
+    email.campaign = 'campaign-id'
     email.send()
 
 Or cc, bcc, reply to, or attachments fields:

--- a/sparkpost/django/message.py
+++ b/sparkpost/django/message.py
@@ -7,6 +7,26 @@ from django.conf import settings
 
 from .exceptions import UnsupportedContent
 
+# API attributes to pass through to Transmissions Class
+sparkpost_attributes = [
+  'substitution_data',
+  'metadata',
+  'description',
+  'return_path',
+  'ip_pool',
+  'inline_css',
+  'transactional',
+  'start_time',
+  'skip_suppression'
+]
+
+# API attributes that need to be transformed for Transmissions Class
+transform_attributes = {
+  'sandbox': 'use_sandbox',
+  'open_tracking': 'track_opens',
+  'click_tracking': 'track_clicks'
+}
+
 
 class SparkPostMessage(dict):
     """
@@ -84,14 +104,19 @@ class SparkPostMessage(dict):
                     'type': mimetype
                 })
 
-        if hasattr(message, 'substitution_data'):
-            formatted['substitution_data'] = message.substitution_data
+        # Set all other extra attributes
+        for attribute in sparkpost_attributes:
+            if hasattr(message, attribute):
+                formatted[attribute] = getattr(message, attribute)
 
+        # Set attributes that need to be transformed for Transmissions Class
+        for key, value in transform_attributes.items():
+            if hasattr(message, key):
+                formatted[value] = getattr(message, key)
+
+        # Not in sparkpost_attributes for backwards comaptibility
         if hasattr(message, 'campaign'):
             formatted['campaign'] = message.campaign
-
-        if hasattr(message, 'metadata'):
-            formatted['metadata'] = message.metadata
 
         if message.extra_headers:
             formatted['custom_headers'] = message.extra_headers

--- a/sparkpost/django/message.py
+++ b/sparkpost/django/message.py
@@ -90,6 +90,9 @@ class SparkPostMessage(dict):
         if hasattr(message, 'campaign'):
             formatted['campaign'] = message.campaign
 
+        if hasattr(message, 'metadata'):
+            formatted['metadata'] = message.metadata
+
         if message.extra_headers:
             formatted['custom_headers'] = message.extra_headers
             if 'X-MSYS-API' in message.extra_headers:

--- a/test/django/test_message.py
+++ b/test/django/test_message.py
@@ -186,34 +186,67 @@ def test_campaign():
     assert actual == expected
 
 
-def test_substitution_data():
+def test_metadata():
     email_message = EmailMessage(
         to=[
             {
-                "address": "to@example.com",
-                "substitution_data": {
-                    "key": "value"
+                'address': 'to@example.com',
+                'metadata': {
+                    'key': 'value'
                 }
             }
         ],
         from_email='test@from.com'
     )
     email_message.template = 'template-id'
-    email_message.substitution_data = {"key2": "value2"}
+    email_message.metadata = {'key2': 'value2'}
     actual = SparkPostMessage(email_message)
 
     expected = dict(
         recipients=[
             {
-                "address": "to@example.com",
-                "substitution_data": {
-                    "key": "value"
+                'address': 'to@example.com',
+                'metadata': {
+                    'key': 'value'
                 }
             }
         ],
         from_email='test@from.com',
         template='template-id',
-        substitution_data={"key2": "value2"}
+        metadata={'key2': 'value2'}
+    )
+
+    assert actual == expected
+
+
+def test_substitution_data():
+    email_message = EmailMessage(
+        to=[
+            {
+                'address': 'to@example.com',
+                'substitution_data': {
+                    'key': 'value'
+                }
+            }
+        ],
+        from_email='test@from.com'
+    )
+    email_message.template = 'template-id'
+    email_message.substitution_data = {'key2': 'value2'}
+    actual = SparkPostMessage(email_message)
+
+    expected = dict(
+        recipients=[
+            {
+                'address': 'to@example.com',
+                'substitution_data': {
+                    'key': 'value'
+                }
+            }
+        ],
+        from_email='test@from.com',
+        template='template-id',
+        substitution_data={'key2': 'value2'}
     )
 
     assert actual == expected


### PR DESCRIPTION
Adding Django support for Transmission API attributes that are supported by the base Python lib class.