### PR TITLE
Fix EU API base URI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ For SparkPost EU and Enterprise accounts, pass in a second parameter to set the 
 .. code-block:: python
 
     from sparkpost import SparkPost
-    sp = SparkPost('YOUR API KEY', 'https://api.eu.sparkpost.com/api')
+    sp = SparkPost('YOUR API KEY', 'https://api.eu.sparkpost.com')
 
 .. _API & SMTP: https://app.sparkpost.com/#/configuration/credentials
 


### PR DESCRIPTION
The `SparkPost__init__` expects the BASE URI without the /api