### PR TITLE
Require later release of requests, to pick up security fixes for CVE-2018-18074

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,4 +23,5 @@ Contributors
 - `@pegler <https://github.com/pegler>`_
 - `@puttu <https://github.com/puttu>`_
 - Janusz Skonieczny `@wooyek <https://github.com/wooyek>`_
+- Richard Dawe `@richdawe77 <https://github.com/rdawemsys>`_
 - ADD YOURSELF HERE (and link to your github page)

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ Install from PyPI using `pip`_:
 
 .. _pip: http://www.pip-installer.org/en/latest/
 
+Python 2.7 or later is required.
 
 Get a key
 ---------

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 flake8
 pytest==2.8.7
 pytest-cov==1.8.1
-requests==2.5.1
+requests==2.20.1
 responses==0.3.0
 mock==2.0.0


### PR DESCRIPTION
requests 2.20.0 was released in order to resolve a security issue. From http://docs.python-requests.org/en/master/community/updates/#release-history :

> Requests removes Authorization header from requests redirected from https to http on the same hostname. (CVE-2018-18074)

Update to requests 2.20.1 to pick up that security fix, plus other bugfixes.

This has the side effect that Python 2.6 is no longer supported, because requests >= 2.20.0 no longer supports Python 2.6.