### PR TITLE
I noticed the documentation said a recipients array will replace the …

### DIFF
--- a/examples/recipient_lists/update_recipient_list_add_single_recipient_maintain_current_recipients.py
+++ b/examples/recipient_lists/update_recipient_list_add_single_recipient_maintain_current_recipients.py
@@ -19,3 +19,4 @@ updated_recipients.append({"address": {"email": email.strip().lower(), "name": "
 response = sp.recipient_lists.update(
     list_id, name="list name", recipients=updated_recipients
 )
+print(response)

--- a/examples/recipient_lists/update_recipient_list_add_single_recipient_maintain_current_recipients.py
+++ b/examples/recipient_lists/update_recipient_list_add_single_recipient_maintain_current_recipients.py
@@ -1,0 +1,21 @@
+from sparkpost import SparkPost
+
+
+# Example list id. Information on getting one is available here:
+# https://developers.sparkpost.com/api/recipient-lists/#recipient-lists-post-create-a-recipient-list
+list_id = "1234"
+
+# Change this from None to the recipient email that should be added to the recipient list
+email = None
+
+sp = SparkPost()
+recipient_list = sp.recipient_lists.get(list_id, True)
+current_recipients = recipient_list["recipients"]
+recipient_values = [recipient["address"] for recipient in current_recipients]
+updated_recipients = [
+    {"address": recipient_value} for recipient_value in recipient_values
+]
+updated_recipients.append({"address": {"email": email.strip().lower(), "name": ""}})
+response = sp.recipient_lists.update(
+    list_id, name="list name", recipients=updated_recipients
+)


### PR DESCRIPTION
…current recipients so I wrote this functionality to overcome that as being able to add a single recipient is useful.

This is the line in the documentation I'm talking about

> If a recipients array is provided in the update request, it will replace the current recipients. This means that if you're adding, updating, or removing a single recipient, the recipients array must contain all current recipients, regardless they are being changed or not.

It comes from this URL [Recipient Lists - Documentation](https://developers.sparkpost.com/api/recipient-lists/#recipient-lists-put-update-a-recipient-list]