### PR TITLE
Allowing US or EU API to be used in the Django backend.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,4 +24,5 @@ Contributors
 - `@puttu <https://github.com/puttu>`_
 - Janusz Skonieczny `@wooyek <https://github.com/wooyek>`_
 - Richard Dawe `@richdawe77 <https://github.com/rdawemsys>`_
+- John Keyes `@jkeyes <https://github.com/jkeyes>`_
 - ADD YOURSELF HERE (and link to your github page)

--- a/README.rst
+++ b/README.rst
@@ -107,9 +107,12 @@ The SparkPost python library comes with an email backend for Django. Put the fol
 .. code-block:: python
 
     SPARKPOST_API_KEY = 'API_KEY'
+    SPARKPOST_BASE_URI = 'api.sparkpost.com'
     EMAIL_BACKEND = 'sparkpost.django.email_backend.SparkPostEmailBackend'
 
 Replace *API_KEY* with an actual API key that you've generated in `Get a Key`_ section. Check out the `full documentation`_ on the Django email backend.
+
+If you are using an EU account, set *SPARKPOST_BASE_URI* to `api.eu.sparkpost.com`. The default value is `api.sparkpost.com`.
 
 .. _full documentation: https://python-sparkpost.readthedocs.io/en/latest/django/backend.html
 

--- a/docs/django/backend.rst
+++ b/docs/django/backend.rst
@@ -11,9 +11,12 @@ To configure Django to use SparkPost, put the following configuration in `settin
 .. code-block:: python
 
     SPARKPOST_API_KEY = 'API_KEY'
+    SPARKPOST_BASE_URI = 'api.sparkpost.com'
     EMAIL_BACKEND = 'sparkpost.django.email_backend.SparkPostEmailBackend'
 
 Replace *API_KEY* with an actual API key.
+
+If you are using an EU account, set *SPARKPOST_BASE_URI* to `api.eu.sparkpost.com`. The default value is `api.sparkpost.com`.
 
 You can also use `SPARKPOST_OPTIONS` to set options that will apply to every transmission.
 For example:

--- a/sparkpost/__init__.py
+++ b/sparkpost/__init__.py
@@ -11,11 +11,14 @@ from .transmissions import Transmissions
 
 __version__ = '1.3.6'
 
+EU_API = 'api.eu.sparkpost.com'
+US_API = 'api.sparkpost.com'
+
 
 class SparkPost(object):
     TRANSPORT_CLASS = RequestsTransport
 
-    def __init__(self, api_key=None, base_uri='https://api.sparkpost.com',
+    def __init__(self, api_key=None, base_uri=US_API,
                  version='1'):
         "Set up the SparkPost API client"
         if not api_key:
@@ -23,7 +26,7 @@ class SparkPost(object):
             if not api_key:
                 raise SparkPostException("No API key. Improve message.")
 
-        self.base_uri = base_uri + '/api/v' + version
+        self.base_uri = 'https://' + base_uri + '/api/v' + version
         self.api_key = api_key
 
         self.metrics = Metrics(self.base_uri, self.api_key,

--- a/sparkpost/django/email_backend.py
+++ b/sparkpost/django/email_backend.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
 
-from sparkpost import SparkPost
+from sparkpost import SparkPost, US_API
 
 from .message import SparkPostMessage
 
@@ -16,8 +16,9 @@ class SparkPostEmailBackend(BaseEmailBackend):
             .__init__(fail_silently=fail_silently, **kwargs)
 
         sp_api_key = getattr(settings, 'SPARKPOST_API_KEY', None)
+        sp_base_uri = getattr(settings, 'SPARKPOST_BASE_URI', US_API)
 
-        self.client = SparkPost(sp_api_key)
+        self.client = SparkPost(sp_api_key, sp_base_uri)
 
     def send_messages(self, email_messages):
         """

--- a/test/django/test_email_backend.py
+++ b/test/django/test_email_backend.py
@@ -7,6 +7,7 @@ from django.core.mail import send_mass_mail
 from django.core.mail import EmailMultiAlternatives
 from django.utils.functional import empty
 
+from sparkpost import EU_API, US_API
 from sparkpost.django.email_backend import SparkPostEmailBackend
 from sparkpost.django.exceptions import UnsupportedContent
 from sparkpost.transmissions import Transmissions
@@ -51,6 +52,17 @@ def mailer(params):
 def test_password_retrieval():
     backend = SparkPostEmailBackend()
     assert backend.client.api_key == API_KEY
+
+
+def test_default_base_uri_retrieval():
+    backend = SparkPostEmailBackend()
+    assert backend.client.base_uri.startswith('https://' + US_API)
+
+
+def test_eu_base_uri_retrieval():
+    reconfigure_settings(SPARKPOST_BASE_URI=EU_API)
+    backend = SparkPostEmailBackend()
+    assert backend.client.base_uri.startswith('https://' + EU_API)
 
 
 def test_fail_silently():


### PR DESCRIPTION
The base URI can be specified in the Django settings module via `SPARKPOST_BASE_URI`.